### PR TITLE
ZeusAdapter: Support IE11 [ZPT-446]

### DIFF
--- a/packages/adapter/lib/ZeusAdapter.js
+++ b/packages/adapter/lib/ZeusAdapter.js
@@ -66,8 +66,7 @@ export class ZeusAdapter {
    * thing Zeus does while starting up is attach itself to the object.
    */
   #waitForZeus = () => {
-    const isZeusReady = () =>
-      globalThis.hasOwnProperty("zeus") && !!globalThis.zeus;
+    const isZeusReady = () => window.hasOwnProperty("zeus") && !!window.zeus;
 
     // Return a promise which resolves once Zeus is ready.
     return new Promise(async resolve => {
@@ -75,7 +74,7 @@ export class ZeusAdapter {
         await delay(ZeusAdapter.WaitQueueDelay);
       }
 
-      return resolve(globalThis.zeus);
+      return resolve(window.zeus);
     });
   };
 

--- a/packages/adapter/lib/ZeusAdapter.js
+++ b/packages/adapter/lib/ZeusAdapter.js
@@ -65,7 +65,7 @@ export class ZeusAdapter {
    * Wait for Zeus to be ready. Zeus is ready when we can see zeus on the global object as the last
    * thing Zeus does while starting up is attach itself to the object.
    */
-  #waitForZeus() {
+  #waitForZeus = () => {
     const isZeusReady = () =>
       globalThis.hasOwnProperty("zeus") && !!globalThis.zeus;
 
@@ -77,7 +77,7 @@ export class ZeusAdapter {
 
       return resolve(globalThis.zeus);
     });
-  }
+  };
 
   /**
    * Connect all hooks the user has requested to the zeus events.

--- a/packages/adapter/lib/ZeusHooks.js
+++ b/packages/adapter/lib/ZeusHooks.js
@@ -8,13 +8,13 @@ export const ZeusHooks = {
   onInitialize: (adapter, userCallback) => userCallback(adapter),
   onZeusAdRegistered: (adapter, userCallback) => {
     // Register for notices on nodes connected
-    globalThis.zeus.on("NODE_CONNECTED", node => {
+    window.zeus.on("NODE_CONNECTED", node => {
       return userCallback(adapter, node.id);
     });
 
     // For all nodes already connected, call the callback
-    if (Array.isArray(globalThis.zeus.adNodes)) {
-      globalThis.zeus.adNodes.forEach(node => {
+    if (Array.isArray(window.zeus.adNodes)) {
+      window.zeus.adNodes.forEach(node => {
         userCallback(adapter, node.id);
       });
     }
@@ -22,20 +22,20 @@ export const ZeusHooks = {
   onBiddingStart: (adapter, userCallback) => {
     // register with Zeus
     const adapterId = uuid();
-    globalThis.zeus.emit("REGISTER_CUSTOM_BIDDER", { adapterId });
+    window.zeus.emit("REGISTER_CUSTOM_BIDDER", { adapterId });
 
     // Setup callback when bidding has started
-    globalThis.zeus.on("CUSTOM_BIDDING_START", slots => {
+    window.zeus.on("CUSTOM_BIDDING_START", slots => {
       Promise.resolve()
         .then(() => userCallback(adapter, slots))
         .then(() =>
-          globalThis.zeus.emit("CUSTOM_BIDDING_FINISHED", {
+          window.zeus.emit("CUSTOM_BIDDING_FINISHED", {
             adapterId,
             success: true
           })
         )
         .catch(error => {
-          globalThis.zeus.emit("CUSTOM_BIDDING_FINISHED", {
+          window.zeus.emit("CUSTOM_BIDDING_FINISHED", {
             adapterId,
             error,
             success: false

--- a/packages/adapter/lib/__tests__/ZeusAdapter/connect.test.js
+++ b/packages/adapter/lib/__tests__/ZeusAdapter/connect.test.js
@@ -3,9 +3,9 @@ import { delay } from "../../utils";
 import EventEmitter from "eventemitter3";
 
 describe("ZeusAdapter.connect()", () => {
-  beforeEach(() => (globalThis.zeus = new EventEmitter()));
+  beforeEach(() => (window.zeus = new EventEmitter()));
   afterEach(() => {
-    delete globalThis.zeus;
+    delete window.zeus;
     jest.clearAllMocks();
     jest.useRealTimers();
   });
@@ -24,7 +24,7 @@ describe("ZeusAdapter.connect()", () => {
 
   it("throws error after timeout if Zeus isn't initialized", async () => {
     // Remove zeus so connect fails
-    delete globalThis.zeus;
+    delete window.zeus;
 
     // Use fake timers so we wont have to wait the full 10 seconds to timeout
     jest.useFakeTimers();
@@ -51,12 +51,12 @@ describe("ZeusAdapter.connect()", () => {
    * 1. Don't define zeus yet
    * 2. Start ZeusAdapter
    * 3. Verify that it has not yet been run.
-   * 4. Now, define Zeus on the globalThis scope.
+   * 4. Now, define Zeus on the window scope.
    * 5. Now verify that the command has been run.
    */
   it("waits for zeus to be initialized when it's not available on connect", async () => {
     // Remove zeus so connect fails
-    delete globalThis.zeus;
+    delete window.zeus;
 
     let isPending = true;
     const onInitialize = jest.fn(() => Promise.resolve());
@@ -67,7 +67,7 @@ describe("ZeusAdapter.connect()", () => {
     expect(onInitialize).not.toHaveBeenCalled();
     expect(isPending).toEqual(true);
 
-    globalThis.zeus = new EventEmitter();
+    window.zeus = new EventEmitter();
 
     await promise; // let the promise finish
 

--- a/packages/adapter/lib/__tests__/ZeusAdapter/runCommand.test.js
+++ b/packages/adapter/lib/__tests__/ZeusAdapter/runCommand.test.js
@@ -28,7 +28,7 @@ describe("ZeusAdapter.#runCommand()", () => {
    * 3. Verify that console.warn was called with the correct warning message
    */
   it("Warns the user if the user callback for a hook does not return a promise", async () => {
-    globalThis.zeus = new EventEmitter();
+    window.zeus = new EventEmitter();
     const onInitializeCallback = jest.fn(() => ({}));
     const adapter = new ZeusAdapter({
       onInitialize: onInitializeCallback
@@ -51,7 +51,7 @@ describe("ZeusAdapter.#runCommand()", () => {
    * 3. Verify that console.warn was called with the correct warning message
    */
   it("Warns the user if the user callback for a hook is not a function", async () => {
-    globalThis.zeus = new EventEmitter();
+    window.zeus = new EventEmitter();
     const onInitializeCallback = {};
     const adapter = new ZeusAdapter({
       onInitialize: onInitializeCallback
@@ -75,7 +75,7 @@ describe("ZeusAdapter.#runCommand()", () => {
    * 3. Verify no console.warns were called.
    */
   it("Just returns the user callback if it is a promise and not a function", async () => {
-    globalThis.zeus = new EventEmitter();
+    window.zeus = new EventEmitter();
     const onInitializeCallback = Promise.resolve();
     const adapter = new ZeusAdapter({
       onInitialize: onInitializeCallback

--- a/packages/adapter/lib/__tests__/ZeusHooks/onBiddingStart.test.js
+++ b/packages/adapter/lib/__tests__/ZeusHooks/onBiddingStart.test.js
@@ -3,11 +3,11 @@ import EventEmitter from "eventemitter3";
 
 describe("ZeusHooks.zeusAdRegistered", () => {
   beforeEach(() => {
-    globalThis.zeus = new EventEmitter();
+    window.zeus = new EventEmitter();
   });
 
   afterEach(() => {
-    delete globalThis.zeus;
+    delete window.zeus;
     jest.clearAllMocks();
   });
 
@@ -20,7 +20,7 @@ describe("ZeusHooks.zeusAdRegistered", () => {
    */
   it("Registers with Zeus", async () => {
     const registerCallback = jest.fn();
-    globalThis.zeus.on("REGISTER_CUSTOM_BIDDER", registerCallback);
+    window.zeus.on("REGISTER_CUSTOM_BIDDER", registerCallback);
 
     await ZeusHooks.onBiddingStart({}, () => {});
 
@@ -49,7 +49,7 @@ describe("ZeusHooks.zeusAdRegistered", () => {
     // Save the adapter ID passed to register custom bidder so we can verify the id passed on
     // CUSTOM_BIDDING_FINSIEHD event back to zeus.
     let adapterId = null;
-    globalThis.zeus.on(
+    window.zeus.on(
       "REGISTER_CUSTOM_BIDDER",
       obj => (adapterId = obj.adapterId)
     );
@@ -62,7 +62,7 @@ describe("ZeusHooks.zeusAdRegistered", () => {
     const biddingFinishedPromise = new Promise(resolve => {
       biddingFinishedCallback = jest.fn(resolve);
     });
-    globalThis.zeus.on("CUSTOM_BIDDING_FINISHED", biddingFinishedCallback);
+    window.zeus.on("CUSTOM_BIDDING_FINISHED", biddingFinishedCallback);
 
     // Setup the hook
     ZeusHooks.onBiddingStart(adapter, userCallback);
@@ -72,7 +72,7 @@ describe("ZeusHooks.zeusAdRegistered", () => {
     expect(biddingFinishedCallback).not.toHaveBeenCalled();
 
     // Start bidding and wait for bidding process to finish
-    globalThis.zeus.emit("CUSTOM_BIDDING_START", slots);
+    window.zeus.emit("CUSTOM_BIDDING_START", slots);
     await biddingFinishedPromise;
 
     // Verify callbacks were called as expected
@@ -106,7 +106,7 @@ describe("ZeusHooks.zeusAdRegistered", () => {
     // Save the adapter ID passed to register custom bidder so we can verify the id passed on
     // CUSTOM_BIDDING_FINSIEHD event back to zeus.
     let adapterId = null;
-    globalThis.zeus.on(
+    window.zeus.on(
       "REGISTER_CUSTOM_BIDDER",
       obj => (adapterId = obj.adapterId)
     );
@@ -119,7 +119,7 @@ describe("ZeusHooks.zeusAdRegistered", () => {
     const biddingFinishedPromise = new Promise(resolve => {
       biddingFinishedCallback = jest.fn(resolve);
     });
-    globalThis.zeus.on("CUSTOM_BIDDING_FINISHED", biddingFinishedCallback);
+    window.zeus.on("CUSTOM_BIDDING_FINISHED", biddingFinishedCallback);
 
     // Setup the hook
     ZeusHooks.onBiddingStart(adapter, userCallback);
@@ -129,7 +129,7 @@ describe("ZeusHooks.zeusAdRegistered", () => {
     expect(biddingFinishedCallback).not.toHaveBeenCalled();
 
     // Start bidding and wait for bidding process to finish
-    globalThis.zeus.emit("CUSTOM_BIDDING_START", slots);
+    window.zeus.emit("CUSTOM_BIDDING_START", slots);
     await biddingFinishedPromise;
 
     // Verify callbacks were called as expected

--- a/packages/adapter/lib/__tests__/ZeusHooks/onZeusAdRegistered.test.js
+++ b/packages/adapter/lib/__tests__/ZeusHooks/onZeusAdRegistered.test.js
@@ -3,36 +3,36 @@ import EventEmitter from "eventemitter3";
 
 describe("ZeusHooks.zeusAdRegistered", () => {
   afterEach(() => {
-    delete globalThis.zeus;
+    delete window.zeus;
     jest.clearAllMocks();
   });
 
   it("Registers the hook with the eventemitter when called", () => {
-    globalThis.zeus = { on: jest.fn() };
+    window.zeus = { on: jest.fn() };
 
     ZeusHooks.onZeusAdRegistered({}, () => {});
 
-    expect(globalThis.zeus.on).toHaveBeenCalledWith(
+    expect(window.zeus.on).toHaveBeenCalledWith(
       "NODE_CONNECTED",
       expect.any(Function)
     );
   });
 
   it('Calls the provided callback with node ids when "NODE_CONNECTED" is emitted', () => {
-    globalThis.zeus = new EventEmitter();
+    window.zeus = new EventEmitter();
     const adapter = { runCommand: jest.fn(cmd => cmd()) };
     const callback = jest.fn();
 
     ZeusHooks.onZeusAdRegistered(adapter, callback);
 
-    globalThis.zeus.emit("NODE_CONNECTED", { id: "foo" });
+    window.zeus.emit("NODE_CONNECTED", { id: "foo" });
 
     expect(callback).toHaveBeenCalledWith(adapter, "foo");
   });
 
   it("Calls callback with node ids for all connected nodes if connect is called after zeus loads", () => {
-    globalThis.zeus = new EventEmitter();
-    globalThis.zeus.adNodes = [{ id: "foo" }];
+    window.zeus = new EventEmitter();
+    window.zeus.adNodes = [{ id: "foo" }];
     const adapter = { runCommand: jest.fn(cmd => cmd()) };
     const callback = jest.fn();
 

--- a/packages/adapter/lib/index.js
+++ b/packages/adapter/lib/index.js
@@ -1,1 +1,17 @@
+/**
+ * Object.entries polyfill from https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/entries#Polyfill
+ * This is because IE 11 doesn't support entries and core-js polyfill is 16kb versus this which is
+ * about 30 bytes.
+ */
+if (!Object.entries) {
+  Object.entries = function(obj) {
+    var ownProps = Object.keys(obj),
+      i = ownProps.length,
+      resArray = new Array(i); // preallocate the Array
+    while (i--) resArray[i] = [ownProps[i], obj[ownProps[i]]];
+
+    return resArray;
+  };
+}
+
 export { ZeusAdapter } from "./ZeusAdapter";


### PR DESCRIPTION
* [NEW] Added Object.entries polyfill function from MDN that adds only 2 bytes compared to 15kb or so for core-js polyfill. 
* [CHG] Changed the `#waitForZeus` function to be a bound function to avoid WeakSet which would have required a large polyfill for IE11. 
* [RM] Removed globalThis which would have required a polyfill in IE11. 
