### PR TITLE
Hotfix: ZeusAdapter build issue

### DIFF
--- a/packages/adapter/babel.config.js
+++ b/packages/adapter/babel.config.js
@@ -8,8 +8,9 @@ module.exports = {
     [
       "@babel/plugin-transform-runtime",
       {
-        regenerator: true
-      }
-    ]
-  ]
+        regenerator: true,
+      },
+    ],
+  ],
+  ignore: ["node_modules"],
 };

--- a/packages/adapter/lib/index.js
+++ b/packages/adapter/lib/index.js
@@ -14,7 +14,4 @@ if (!Object.entries) {
   };
 }
 
-import { ZeusAdapter } from "./ZeusAdapter";
-
-export default ZeusAdapter;
-export { ZeusAdapter };
+export { ZeusAdapter } from "./ZeusAdapter";

--- a/packages/adapter/lib/index.js
+++ b/packages/adapter/lib/index.js
@@ -14,4 +14,7 @@ if (!Object.entries) {
   };
 }
 
-export { ZeusAdapter } from "./ZeusAdapter";
+import { ZeusAdapter } from "./ZeusAdapter";
+
+export default ZeusAdapter;
+export { ZeusAdapter };


### PR DESCRIPTION
Babel was compiling things in node modules causing the built json to fail. Added `node_modules` to babel ignore. 

* [FIX] Fixed build and runtime issues by ignoring node_modules when transpiling. 